### PR TITLE
Added function to compute mean IOU for all classes

### DIFF
--- a/official/vision/evaluation/iou.py
+++ b/official/vision/evaluation/iou.py
@@ -119,6 +119,10 @@ class PerClassIoU(tf.keras.metrics.Metric):
 
     return tf.math.divide_no_nan(true_positives, denominator)
 
+  def get_miou(self):
+    """Compute the mean intersection-over-union for all classes"""
+    return self.result().numpy().mean()
+
   def reset_states(self):
     tf.keras.backend.set_value(
         self.total_cm, np.zeros((self.num_classes, self.num_classes)))


### PR DESCRIPTION
The result of the previous function gave the IOU for each class so made functionality to provide the mean IOU of all the classes, which is needed for MaskFormer metrics.